### PR TITLE
Fix thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The node has 1 input with `(4 topic-payloads)` and 1 output `(object with 4 payl
 ## Input
 You have to set 4 payloads for success function:
 
-* topic: `switch`, payload: true/false, you can force to switch on or off the thermostat
+* topic: `switch`, payload: true/false/auto, you can force to switch the thermostat on or off, `"auto"` to return to automatic mode
 * topic: `target`, payload: target temperatur, e.g. `23`
 * topic: `current`, payload: current temperatur, e.g. `19` (comes from your thermometer)
 * topic: `hysteresis`, payload: target temperatur, e.g. `0.3`

--- a/src/thermostat.js
+++ b/src/thermostat.js
@@ -16,7 +16,7 @@ module.exports = function (RED) {
       node.hysteresis = null
       node.switch = null
 
-      node.context.set('switch', true)
+      node.context.set('switch', null)
 
       if (msg.topic === 'target') {
         node.context.set('target', msg.payload)
@@ -42,10 +42,15 @@ module.exports = function (RED) {
 
       if (node.current !== undefined && node.target !== undefined && node.hysteresis !== undefined) {
         statusColor = 'green'
-        if (node.switch === false) {
-          result = Calc(node.current, node.target, node.hysteresis)
+        if (node.switch === true) {
+            // automatic switching disabled, always stay on
+            result = true
+        } else if(node.switch === false) {
+            // automatic switching disabled, always stay off
+            result = false
         } else {
-          result = true
+            // automatic switching enabled
+            result = Calc(node.current, node.target, node.hysteresis)
         }
       }
 


### PR DESCRIPTION
As discussed in #31 and #33, the thermostat node currently doesn't work. This PR fixes it.

It introduces a third state for the `switch` message. You can send in a message with topic `switch` and payload `true` to have the thermostat always stay on, `false` to have the thermostat always stay off and `"auto" (or rather, anything else except true/false) to return the thermostat into automatic (temperature dependent) mode.